### PR TITLE
Last sleep's score should be "score" measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- add `score` unit of measurement for sleep score
+
 ## 1.1.0
 
 - fix url callback building

--- a/custom_components/polar/manifest.json
+++ b/custom_components/polar/manifest.json
@@ -15,5 +15,5 @@
   "requirements": [
     "isodate==0.6.1"
   ],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/polar/sensor.py
+++ b/custom_components/polar/sensor.py
@@ -104,6 +104,7 @@ SENSORS = (
         key="sleep_score",
         name="Last sleep score",
         unique_id="last_sleep",
+        native_unit_of_measurement="score",
         attributes_keys=[
             "date",
             "sleep_start_time",


### PR DESCRIPTION
The "last sleep score" sensor is missing the native unit of measurement "score". 

Before my patch the sensor is displayed as a bar:
![image](https://user-images.githubusercontent.com/73690/226864384-9cc0c97e-c86c-48a3-a2af-e3612482bc05.png)

After my patch it's a graph:
![image](https://user-images.githubusercontent.com/73690/226864213-6f86bc26-1357-4a08-996e-080ed6965d6e.png)
